### PR TITLE
 Add retain_all to get_streets() for perimeter

### DIFF
--- a/prettymaps/fetch.py
+++ b/prettymaps/fetch.py
@@ -170,6 +170,7 @@ def get_streets(
             unary_union(perimeter.geometry).buffer(buffer)
             if buffer > 0
             else unary_union(perimeter.geometry),
+            retain_all=retain_all,
             custom_filter=custom_filter,
         )
         streets = ox.project_graph(streets)


### PR DESCRIPTION
Commit #33 added the option, but only when specifying a point and radius, not a perimeter.